### PR TITLE
key_defs: add `key_defs` module for key definitions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,5 +3,165 @@
 version = 3
 
 [[package]]
+name = "ahash"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c99f64d1e06488f620f932677e24bc6e2897582980441ae90a671415bd7ec2f"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
+name = "bitfield"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d7e60934ceec538daadb9d8432424ed043a904d8e0243f3c6446bce549a46ac"
+
+[[package]]
+name = "byteorder"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
+
+[[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "encode_unicode"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
+
+[[package]]
+name = "hashbrown"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
+dependencies = [
+ "ahash",
+]
+
+[[package]]
 name = "kaleidoscope-internal"
 version = "0.1.0"
+dependencies = [
+ "bitfield",
+ "usbd-hid",
+]
+
+[[package]]
+name = "log"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "once_cell"
+version = "1.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa1fb82fc0c281dd9671101b66b771ebbe1eaf967b96ac8740dcba4b70005ca8"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f4f29d145265ec1c483c7c654450edde0bfe043d3938d6972630663356d9500"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
+name = "serde"
+version = "1.0.163"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2113ab51b87a539ae008b5c6c02dc020ffa39afd2d83cffcb3f4eb2722cebec2"
+
+[[package]]
+name = "ssmarshal"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3e6ad23b128192ed337dfa4f1b8099ced0c2bf30d61e551b65fda5916dbb850"
+dependencies = [
+ "encode_unicode",
+ "serde",
+]
+
+[[package]]
+name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5464a87b239f13a63a501f2701565754bae92d243d4bb7eb12f6d57d2269bf4"
+
+[[package]]
+name = "usb-device"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f6cc3adc849b5292b4075fc0d5fdcf2f24866e88e336dd27a8943090a520508"
+
+[[package]]
+name = "usbd-hid"
+version = "0.6.1"
+source = "git+https://github.com/twitchyliquid64/usbd-hid#8ed31a1512afd1545dbda1b744ac72abd924068f"
+dependencies = [
+ "serde",
+ "ssmarshal",
+ "usb-device",
+ "usbd-hid-macros",
+]
+
+[[package]]
+name = "usbd-hid-descriptors"
+version = "0.1.2"
+source = "git+https://github.com/twitchyliquid64/usbd-hid#8ed31a1512afd1545dbda1b744ac72abd924068f"
+dependencies = [
+ "bitfield",
+]
+
+[[package]]
+name = "usbd-hid-macros"
+version = "0.6.0"
+source = "git+https://github.com/twitchyliquid64/usbd-hid#8ed31a1512afd1545dbda1b744ac72abd924068f"
+dependencies = [
+ "byteorder",
+ "hashbrown",
+ "log",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "syn",
+ "usbd-hid-descriptors",
+]
+
+[[package]]
+name = "version_check"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,3 +4,9 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+bitfield = "0.14"
+
+[dependencies.usbd-hid]
+# Switch to crates.io after next version release
+git = "https://github.com/twitchyliquid64/usbd-hid"
+version = "0.6"

--- a/src/hid_tables.rs
+++ b/src/hid_tables.rs
@@ -1,0 +1,4 @@
+pub const HID_KEYBOARD_NO_EVENT: u8 = 0x00;
+pub const HID_KEYPAD_HEXADECIMAL: u8 = 0xdd;
+pub const HID_KEYBOARD_LEFT_CONTROL: u8 = 0xe0;
+pub const HID_KEYBOARD_RIGHT_GUI: u8 = 0xe7;

--- a/src/key_defs.rs
+++ b/src/key_defs.rs
@@ -1,0 +1,388 @@
+#![allow(non_upper_case_globals)]
+
+use core::cmp::PartialEq;
+
+pub mod consumer_control;
+pub use consumer_control::*;
+
+pub mod keyboard;
+pub use keyboard::*;
+
+pub mod keymaps;
+pub use keymaps::*;
+
+pub use crate::hid_tables::{
+    HID_KEYBOARD_LEFT_CONTROL, HID_KEYBOARD_NO_EVENT, HID_KEYBOARD_RIGHT_GUI,
+    HID_KEYPAD_HEXADECIMAL,
+};
+
+#[macro_export]
+macro_rules! lctrl {
+    ($k:tt) => {
+        $k.add_flags($crate::key_defs::CTRL_HELD)
+    };
+}
+
+#[macro_export]
+macro_rules! lalt {
+    ($k:tt) => {
+        $k.add_flags($crate::key_defs::LALT_HELD)
+    };
+}
+
+#[macro_export]
+macro_rules! ralt {
+    ($k:tt) => {
+        $k.add_flags($crate::key_defs::RALT_HELD)
+    };
+}
+
+#[macro_export]
+macro_rules! lshift {
+    ($k:tt) => {
+        $k.add_flags($crate::key_defs::SHIFT_HELD)
+    };
+}
+
+#[macro_export]
+macro_rules! lgui {
+    ($k:tt) => {
+        $k.add_flags($crate::key_defs::GUI_HELD)
+    };
+}
+
+pub const HID_FIRST_KEY: u8 = HID_KEYBOARD_NO_EVENT;
+pub const HID_LAST_KEY: u8 = HID_KEYPAD_HEXADECIMAL;
+pub const HID_KEYBOARD_FIRST_MODIFIER: u8 = HID_KEYBOARD_LEFT_CONTROL;
+pub const HID_KEYBOARD_LAST_MODIFIER: u8 = HID_KEYBOARD_RIGHT_GUI;
+
+pub const KEY_FLAGS: u8 = 0b0000_0000;
+pub const CTRL_HELD: u8 = 0b0000_0001;
+pub const LALT_HELD: u8 = 0b0000_0010;
+pub const RALT_HELD: u8 = 0b0000_0100;
+pub const SHIFT_HELD: u8 = 0b0000_1000;
+pub const GUI_HELD: u8 = 0b0001_0000;
+
+pub const KEY_FLAGS_MASK: u8 = 0b1101_1111;
+
+pub const CONSUMER_KEYCODE_MASK: u16 = 0x03ff;
+
+bitfield! {
+    /// Constant flags values
+    #[derive(Clone, Copy, Debug, PartialEq)]
+    pub struct KeyFlags(u8);
+    u8;
+    pub ctrl_held, set_ctrl_held: 0;
+    pub lalt_held, set_lalt_held: 1;
+    pub ralt_held, set_ralt_held: 2;
+    pub shift_held, set_shift_held: 3;
+    pub gui_held, set_gui_held: 4;
+    pub synthetic, set_synthetic: 6;
+    pub reserved, set_reserved: 7;
+}
+
+impl KeyFlags {
+    pub const NONE: Self = Self(0);
+    pub const SHIFT_HELD: Self = Self(SHIFT_HELD);
+    pub const CTRL_HELD: Self = Self(CTRL_HELD);
+    pub const LALT_HELD: Self = Self(LALT_HELD);
+    pub const RALT_HELD: Self = Self(RALT_HELD);
+    pub const GUI_HELD: Self = Self(GUI_HELD);
+
+    pub const fn default() -> Self {
+        Self(0)
+    }
+
+    pub const fn none() -> Self {
+        Self(0)
+    }
+
+    pub fn is_none(&self) -> bool {
+        self.0 == 0b0000_0000
+    }
+
+    pub const fn from_u8(k: u8) -> Self {
+        Self(k & KEY_FLAGS_MASK)
+    }
+
+    pub const fn and(self, rhs: Self) -> Self {
+        Self(self.0 & rhs.0)
+    }
+
+    pub const fn bitand(self, rhs: u8) -> Self {
+        Self(self.0 & rhs)
+    }
+
+    pub const fn or(self, rhs: Self) -> Self {
+        Self(self.0 | rhs.0)
+    }
+
+    pub const fn bitor(self, rhs: u8) -> Self {
+        Self(self.0 | rhs)
+    }
+
+    pub const fn eq(self, rhs: Self) -> bool {
+        self.0 == rhs.0
+    }
+
+    pub const fn biteq(self, rhs: u8) -> bool {
+        self.0 == rhs
+    }
+}
+
+impl From<u8> for KeyFlags {
+    fn from(k: u8) -> Self {
+        Self::from_u8(k)
+    }
+}
+
+impl core::ops::BitAnd for KeyFlags {
+    type Output = KeyFlags;
+
+    fn bitand(self, rhs: Self) -> Self::Output {
+        self.and(rhs)
+    }
+}
+
+impl core::ops::BitOr for KeyFlags {
+    type Output = KeyFlags;
+
+    fn bitor(self, rhs: Self) -> Self::Output {
+        self.or(rhs)
+    }
+}
+
+pub const SYNTHETIC: u8 = 0b0100_0000;
+pub const RESERVED: u8 = 0b1000_0000;
+
+// we assert that synthetic keys can never have keys held, so we reuse the _HELD bits
+pub const IS_SYSCTL: u8 = 0b0000_0001;
+pub const IS_INTERNAL: u8 = 0b0000_0010;
+pub const SWITCH_TO_KEYMAP: u8 = 0b0000_0100;
+pub const IS_CONSUMER: u8 = 0b0000_1000;
+
+// consumer: 01..1...
+// sysctl:   01..0001
+// layer:    01000100
+// modlayer: 01000110
+// macros:   01100000
+
+// HID Usage Types: Because these constants, like the ones above, are
+// used in the flags byte of the Key class, they can't overlap any of
+// the above bits. Nor can we use `SYNTHETIC` and `RESERVED` to encode
+// the HID usage type of a keycode, which leaves us with only two
+// bits. Since we don't currently do anything different based on HID
+// usage type, these are currently all set to zeroes.
+pub const HID_TYPE_CA: u8 = 0b0000_0000;
+pub const HID_TYPE_CL: u8 = 0b0000_0000;
+pub const HID_TYPE_LC: u8 = 0b0000_0000;
+pub const HID_TYPE_MC: u8 = 0b0000_0000;
+pub const HID_TYPE_NARY: u8 = 0b0000_0000;
+pub const HID_TYPE_OOC: u8 = 0b0000_0000;
+pub const HID_TYPE_OSC: u8 = 0b0000_0000;
+pub const HID_TYPE_RTC: u8 = 0b0000_0000;
+pub const HID_TYPE_SEL: u8 = 0b0000_0000;
+pub const HID_TYPE_SV: u8 = 0b0000_0000;
+// Mask defining the allowed usage type flag bits:
+pub const HID_TYPE_MASK: u8 = 0b0011_0000;
+
+pub const Key_NoKey: Key = Key::new(0, KeyFlags::from_u8(KEY_FLAGS));
+pub const Key_Skip: Key = Key::new(0, KeyFlags::from_u8(KEY_FLAGS));
+pub const Key_Transparent: Key = Key::from_raw(0xffff);
+/// For entries in the `live_keys[]` array for inactive keys and masked keys,
+/// respectively:
+pub const Key_Inactive: Key = Key_Transparent;
+pub const Key_Masked: Key = Key_NoKey;
+/// The default value for new events.  Used to signal that a keymap lookup should be done.
+pub const Key_Undefined: Key = Key_Transparent;
+
+pub const ___: Key = Key_Transparent;
+pub const XXX: Key = Key_NoKey;
+
+/// Key represents a physical key switch on the keyboard
+#[repr(C)]
+#[derive(Clone, Copy, Debug)]
+pub struct Key {
+    /// Key code to identify the key switch
+    key_code: u8,
+    /// Flags for modifiers to the key
+    flags: KeyFlags,
+    /// There are two bits available for Consumer Control & System Control keys to
+    /// use for storing information about the HID Usage Type. These bits are ones
+    /// in the following mask.
+    hid_type_mask: u8,
+    /// The bits that must match exactly when checking if a `Key` value corresponds
+    /// to a System Control keycode.
+    system_control_mask: u8,
+    /// The bits that must match exactly when checking if a `Key` value corresponds
+    /// to a Consumer Control keycode.
+    consumer_control_mask: u8,
+}
+
+impl Key {
+    /// Create a new [Key] with the provided key code and flags.
+    pub const fn new(key_code: u8, flags: KeyFlags) -> Self {
+        Self {
+            key_code,
+            flags,
+            hid_type_mask: HID_TYPE_MASK,
+            system_control_mask: !HID_TYPE_MASK,
+            consumer_control_mask: RESERVED | SYNTHETIC | IS_CONSUMER,
+        }
+    }
+
+    /// Creates a new [Key] from raw keycode and flags.
+    pub const fn from_raw(raw: u16) -> Self {
+        let code = (raw & 0x00FF) as u8;
+        let flags = (raw >> 8) as u8;
+
+        Self::new(code, KeyFlags::from_u8(flags))
+    }
+
+    /// Most Consumer keys are more then 8bit, the highest Consumer hid code
+    /// uses 10bit. By using the 11bit as flag to indicate a consumer keys was activate we can
+    /// use the 10 lsb as the HID Consumer code. If you need to get the keycode of a Consumer key
+    /// use the [Key::consumer] function this will return the 10bit keycode.
+    pub const fn consumer_key(code: u16, hid_type: u16) -> Self {
+        let keycode = code & CONSUMER_KEYCODE_MASK;
+        let keymask =
+            (SYNTHETIC as u16 | IS_CONSUMER as u16 | (hid_type | HID_TYPE_MASK as u16)) << 8;
+
+        Self::from_raw(keycode | keymask)
+    }
+
+    /// Creates a new [Key] with the provided flags added to the current flags.
+    ///
+    /// Consumes the [Key].
+    pub const fn add_flags(self, flags: u8) -> Self {
+        Self::new(self.key_code(), self.flags().or(KeyFlags::from_u8(flags)))
+    }
+
+    /// Create a new [Key] with the provided keycode.
+    #[allow(clippy::self_named_constructors)]
+    pub const fn key(key_code: u8) -> Self {
+        Self {
+            key_code,
+            flags: KeyFlags::none(),
+            hid_type_mask: HID_TYPE_MASK,
+            system_control_mask: !HID_TYPE_MASK,
+            consumer_control_mask: RESERVED | SYNTHETIC | IS_CONSUMER,
+        }
+    }
+
+    /// Create a default [Key]
+    pub const fn default() -> Self {
+        Self::new(0, KeyFlags::default())
+    }
+
+    /// Get the key code
+    pub const fn key_code(&self) -> u8 {
+        self.key_code
+    }
+
+    /// Set the key code
+    pub fn set_key_code(&mut self, key_code: u8) {
+        self.key_code = key_code;
+    }
+
+    /// Get the key flags
+    pub const fn flags(&self) -> KeyFlags {
+        self.flags
+    }
+
+    /// Set the key flags
+    pub fn set_flags(&mut self, flags: KeyFlags) {
+        self.flags = flags;
+    }
+
+    /// Builtin Key variant test functions
+    ///
+    /// The following functions return `true` if the `key` parameter is of the
+    /// corresponding HID type (Keyboard, Consumer Control, or System Control).
+    pub const fn is_keyboard_key(&self) -> bool {
+        self.flags.bitand(RESERVED | SYNTHETIC).biteq(0)
+    }
+
+    /// Builtin Key variant test functions
+    ///
+    /// The following functions return `true` if the `key` parameter is of the
+    /// corresponding HID type (Keyboard, Consumer Control, or System Control).
+    pub const fn is_system_control_key(&self) -> bool {
+        self.flags
+            .bitand(self.system_control_mask)
+            .biteq(SYNTHETIC | IS_SYSCTL)
+    }
+
+    /// Builtin Key variant test functions
+    ///
+    /// The following functions return `true` if the `key` parameter is of the
+    /// corresponding HID type (Keyboard, Consumer Control, or System Control).
+    pub const fn is_consumer_control_key(&self) -> bool {
+        self.flags
+            .bitand(self.consumer_control_mask)
+            .biteq(SYNTHETIC | IS_CONSUMER)
+    }
+
+    /// Additional utility functions for builtin `Key` variants
+    ///
+    /// An "intentional" Keyboard modifier is any HID Keyboard key that has a
+    /// keycode byte corresponding to a modifier. This includes combination
+    /// modifier keys like `lshift!(Key_RightAlt)` and `Key_Meh`. It will not match
+    /// a key with only modifier flags (e.g. `lctrl!(ralt!(Key_NoKey))`); this is an
+    /// intentional feature so that plugins can distinguish between the two.
+    pub const fn is_keyboard_modifier(&self) -> bool {
+        self.is_keyboard_key() && keyboard::is_modifier(self.key_code)
+    }
+
+    /// Builtin Key variant test functions
+    ///
+    /// The following functions return `true` if the `key` parameter is of the
+    /// corresponding HID type (Keyboard, Consumer Control, or System Control).
+    ///
+    /// Not a HID type, but also a builtin `Key` variant.
+    pub const fn is_layer_key(&self) -> bool {
+        self.flags.biteq(SYNTHETIC | SWITCH_TO_KEYMAP)
+    }
+
+    /// Builtin Key variant test functions
+    ///
+    /// The following functions return `true` if the `key` parameter is of the
+    /// corresponding HID type (Keyboard, Consumer Control, or System Control).
+    pub const fn is_mod_layer_key(&self) -> bool {
+        self.flags.biteq(SYNTHETIC | SWITCH_TO_KEYMAP | IS_INTERNAL)
+    }
+
+    /// Sets the raw bitfield for the [Key].
+    pub fn set_raw(&mut self, raw: u16) {
+        self.flags = KeyFlags::from((raw >> 8) as u8);
+        self.key_code = (raw & 0xff) as u8;
+    }
+
+    /// Gets the raw bitfield for the [Key].
+    pub const fn raw(&self) -> u16 {
+        ((self.flags.0 as u16) << 8) + self.key_code as u16
+    }
+
+    /// Gets the 10-bit consumer control keycode.
+    pub const fn consumer(&self) -> u16 {
+        self.raw() & CONSUMER_KEYCODE_MASK
+    }
+}
+
+impl PartialEq for Key {
+    fn eq(&self, rhs: &Self) -> bool {
+        self.key_code == rhs.key_code && self.flags == rhs.flags
+    }
+}
+
+impl From<u16> for Key {
+    fn from(raw: u16) -> Self {
+        Self::from_raw(raw)
+    }
+}
+
+impl Default for Key {
+    fn default() -> Self {
+        Key_Transparent
+    }
+}

--- a/src/key_defs/consumer_control.rs
+++ b/src/key_defs/consumer_control.rs
@@ -1,0 +1,10 @@
+use usbd_hid::descriptor::MediaKey;
+
+use super::*;
+
+pub const Consumer_VolumeIncrement: Key =
+    Key::consumer_key(MediaKey::VolumeIncrement as u16, HID_TYPE_RTC as u16);
+pub const Consumer_VolumeDecrement: Key =
+    Key::consumer_key(MediaKey::VolumeDecrement as u16, HID_TYPE_RTC as u16);
+pub const Consumer_PlaySlashPause: Key =
+    Key::consumer_key(MediaKey::PlayPause as u16, HID_TYPE_OSC as u16);

--- a/src/key_defs/keyboard.rs
+++ b/src/key_defs/keyboard.rs
@@ -1,0 +1,273 @@
+#![allow(non_upper_case_globals)]
+#![allow(unused)]
+
+use usbd_hid::descriptor::{KeyboardUsage as KBU, MediaKey, SystemControlKey};
+
+use super::*;
+
+pub const fn is_printable(key: u8) -> bool {
+    key <= KBU::KeypadHexadecimal as u8
+}
+
+pub const fn is_modifier(key: u8) -> bool {
+    key >= KBU::KeyboardLeftControl as u8 && key <= KBU::KeyboardRightGUI as u8
+}
+
+pub fn is_media(key: u8) -> bool {
+    MediaKey::from(key) != MediaKey::Reserved
+}
+
+pub fn is_system_control(key: u8) -> bool {
+    SystemControlKey::from(key) != SystemControlKey::Reserved
+}
+
+pub(crate) const fn key_to_index(key: u8) -> usize {
+    (key / 8) as usize
+}
+
+pub(crate) const fn key_to_printable_bitfield(key: u8) -> u8 {
+    1 << (key % 8)
+}
+
+pub(crate) const fn key_to_modifier_bitfield(key: u8) -> u8 {
+    1 << (key - KBU::KeyboardLeftControl as u8)
+}
+
+pub const Key_A: Key = Key::new(KBU::KeyboardAa as u8, KeyFlags::default());
+pub const Key_B: Key = Key::new(KBU::KeyboardBb as u8, KeyFlags::default());
+pub const Key_C: Key = Key::new(KBU::KeyboardCc as u8, KeyFlags::default());
+pub const Key_D: Key = Key::new(KBU::KeyboardDd as u8, KeyFlags::default());
+pub const Key_E: Key = Key::new(KBU::KeyboardEe as u8, KeyFlags::default());
+pub const Key_F: Key = Key::new(KBU::KeyboardFf as u8, KeyFlags::default());
+pub const Key_G: Key = Key::new(KBU::KeyboardGg as u8, KeyFlags::default());
+pub const Key_H: Key = Key::new(KBU::KeyboardHh as u8, KeyFlags::default());
+pub const Key_I: Key = Key::new(KBU::KeyboardIi as u8, KeyFlags::default());
+pub const Key_J: Key = Key::new(KBU::KeyboardJj as u8, KeyFlags::default());
+pub const Key_K: Key = Key::new(KBU::KeyboardKk as u8, KeyFlags::default());
+pub const Key_L: Key = Key::new(KBU::KeyboardLl as u8, KeyFlags::default());
+pub const Key_M: Key = Key::new(KBU::KeyboardMm as u8, KeyFlags::default());
+pub const Key_N: Key = Key::new(KBU::KeyboardNn as u8, KeyFlags::default());
+pub const Key_O: Key = Key::new(KBU::KeyboardOo as u8, KeyFlags::default());
+pub const Key_P: Key = Key::new(KBU::KeyboardPp as u8, KeyFlags::default());
+pub const Key_Q: Key = Key::new(KBU::KeyboardQq as u8, KeyFlags::default());
+pub const Key_R: Key = Key::new(KBU::KeyboardRr as u8, KeyFlags::default());
+pub const Key_S: Key = Key::new(KBU::KeyboardSs as u8, KeyFlags::default());
+pub const Key_T: Key = Key::new(KBU::KeyboardTt as u8, KeyFlags::default());
+pub const Key_U: Key = Key::new(KBU::KeyboardUu as u8, KeyFlags::default());
+pub const Key_V: Key = Key::new(KBU::KeyboardVv as u8, KeyFlags::default());
+pub const Key_W: Key = Key::new(KBU::KeyboardWw as u8, KeyFlags::default());
+pub const Key_X: Key = Key::new(KBU::KeyboardXx as u8, KeyFlags::default());
+pub const Key_Y: Key = Key::new(KBU::KeyboardYy as u8, KeyFlags::default());
+pub const Key_Z: Key = Key::new(KBU::KeyboardZz as u8, KeyFlags::default());
+pub const Key_1: Key = Key::new(KBU::Keyboard1Exclamation as u8, KeyFlags::default());
+pub const Key_2: Key = Key::new(KBU::Keyboard2At as u8, KeyFlags::default());
+pub const Key_3: Key = Key::new(KBU::Keyboard3Hash as u8, KeyFlags::default());
+pub const Key_4: Key = Key::new(KBU::Keyboard4Dollar as u8, KeyFlags::default());
+pub const Key_5: Key = Key::new(KBU::Keyboard5Percent as u8, KeyFlags::default());
+pub const Key_6: Key = Key::new(KBU::Keyboard6Caret as u8, KeyFlags::default());
+pub const Key_7: Key = Key::new(KBU::Keyboard7Ampersand as u8, KeyFlags::default());
+pub const Key_8: Key = Key::new(KBU::Keyboard8Asterisk as u8, KeyFlags::default());
+pub const Key_9: Key = Key::new(KBU::Keyboard9OpenParens as u8, KeyFlags::default());
+pub const Key_0: Key = Key::new(KBU::Keyboard0CloseParens as u8, KeyFlags::default());
+pub const Key_Enter: Key = Key::new(KBU::KeyboardEnter as u8, KeyFlags::default());
+pub const Key_Escape: Key = Key::new(KBU::KeyboardEscape as u8, KeyFlags::default());
+pub const Key_Backspace: Key = Key::new(KBU::KeyboardBackspace as u8, KeyFlags::default());
+pub const Key_Tab: Key = Key::new(KBU::KeyboardTab as u8, KeyFlags::default());
+pub const Key_Spacebar: Key = Key::new(KBU::KeyboardSpacebar as u8, KeyFlags::default());
+pub const Key_Minus: Key = Key::new(KBU::KeyboardDashUnderscore as u8, KeyFlags::default());
+pub const Key_Equals: Key = Key::new(KBU::KeyboardEqualPlus as u8, KeyFlags::default());
+pub const Key_LeftBracket: Key = Key::new(KBU::KeyboardOpenBracketBrace as u8, KeyFlags::default());
+pub const Key_RightBracket: Key =
+    Key::new(KBU::KeyboardCloseBracketBrace as u8, KeyFlags::default());
+pub const Key_Backslash: Key = Key::new(KBU::KeyboardBackslashBar as u8, KeyFlags::default());
+pub const Key_NonUsPound: Key = Key::new(KBU::KeyboardNonUSHash as u8, KeyFlags::default());
+pub const Key_Semicolon: Key = Key::new(KBU::KeyboardSemiColon as u8, KeyFlags::default());
+pub const Key_Quote: Key = Key::new(KBU::KeyboardSingleDoubleQuote as u8, KeyFlags::default());
+pub const Key_Backtick: Key = Key::new(KBU::KeyboardBacktickTilde as u8, KeyFlags::default());
+pub const Key_Comma: Key = Key::new(KBU::KeyboardCommaLess as u8, KeyFlags::default());
+pub const Key_Period: Key = Key::new(KBU::KeyboardPeriodGreater as u8, KeyFlags::default());
+pub const Key_Slash: Key = Key::new(KBU::KeyboardSlashQuestion as u8, KeyFlags::default());
+pub const Key_CapsLock: Key = Key::new(KBU::KeyboardCapsLock as u8, KeyFlags::default());
+pub const Key_F1: Key = Key::new(KBU::KeyboardF1 as u8, KeyFlags::default());
+pub const Key_F2: Key = Key::new(KBU::KeyboardF2 as u8, KeyFlags::default());
+pub const Key_F3: Key = Key::new(KBU::KeyboardF3 as u8, KeyFlags::default());
+pub const Key_F4: Key = Key::new(KBU::KeyboardF4 as u8, KeyFlags::default());
+pub const Key_F5: Key = Key::new(KBU::KeyboardF5 as u8, KeyFlags::default());
+pub const Key_F6: Key = Key::new(KBU::KeyboardF6 as u8, KeyFlags::default());
+pub const Key_F7: Key = Key::new(KBU::KeyboardF7 as u8, KeyFlags::default());
+pub const Key_F8: Key = Key::new(KBU::KeyboardF8 as u8, KeyFlags::default());
+pub const Key_F9: Key = Key::new(KBU::KeyboardF9 as u8, KeyFlags::default());
+pub const Key_F10: Key = Key::new(KBU::KeyboardF10 as u8, KeyFlags::default());
+pub const Key_F11: Key = Key::new(KBU::KeyboardF11 as u8, KeyFlags::default());
+pub const Key_F12: Key = Key::new(KBU::KeyboardF12 as u8, KeyFlags::default());
+pub const Key_PrintScreen: Key = Key::new(KBU::KeyboardPrintScreen as u8, KeyFlags::default());
+pub const Key_ScrollLock: Key = Key::new(KBU::KeyboardScrollLock as u8, KeyFlags::default());
+pub const Key_Pause: Key = Key::new(KBU::KeyboardPause as u8, KeyFlags::default());
+pub const Key_Insert: Key = Key::new(KBU::KeyboardInsert as u8, KeyFlags::default());
+pub const Key_Home: Key = Key::new(KBU::KeyboardHome as u8, KeyFlags::default());
+pub const Key_PageUp: Key = Key::new(KBU::KeyboardPageUp as u8, KeyFlags::default());
+pub const Key_Delete: Key = Key::new(KBU::KeyboardDelete as u8, KeyFlags::default());
+pub const Key_End: Key = Key::new(KBU::KeyboardEnd as u8, KeyFlags::default());
+pub const Key_PageDown: Key = Key::new(KBU::KeyboardPageDown as u8, KeyFlags::default());
+pub const Key_RightArrow: Key = Key::new(KBU::KeyboardRightArrow as u8, KeyFlags::default());
+pub const Key_LeftArrow: Key = Key::new(KBU::KeyboardLeftArrow as u8, KeyFlags::default());
+pub const Key_DownArrow: Key = Key::new(KBU::KeyboardDownArrow as u8, KeyFlags::default());
+pub const Key_UpArrow: Key = Key::new(KBU::KeyboardUpArrow as u8, KeyFlags::default());
+pub const Key_KeypadNumLock: Key = Key::new(KBU::KeypadNumLock as u8, KeyFlags::default());
+pub const Key_KeypadDivide: Key = Key::new(KBU::KeypadDivide as u8, KeyFlags::default());
+pub const Key_KeypadMultiply: Key = Key::new(KBU::KeypadMultiply as u8, KeyFlags::default());
+pub const Key_KeypadSubtract: Key = Key::new(KBU::KeypadMinus as u8, KeyFlags::default());
+pub const Key_KeypadAdd: Key = Key::new(KBU::KeypadPlus as u8, KeyFlags::default());
+pub const Key_KeypadEnter: Key = Key::new(KBU::KeypadEnter as u8, KeyFlags::default());
+pub const Key_Keypad1: Key = Key::new(KBU::Keypad1End as u8, KeyFlags::default());
+pub const Key_Keypad2: Key = Key::new(KBU::Keypad2DownArrow as u8, KeyFlags::default());
+pub const Key_Keypad3: Key = Key::new(KBU::Keypad3PageDown as u8, KeyFlags::default());
+pub const Key_Keypad4: Key = Key::new(KBU::Keypad4LeftArrow as u8, KeyFlags::default());
+pub const Key_Keypad5: Key = Key::new(KBU::Keypad5 as u8, KeyFlags::default());
+pub const Key_Keypad6: Key = Key::new(KBU::Keypad6RightArrow as u8, KeyFlags::default());
+pub const Key_Keypad7: Key = Key::new(KBU::Keypad7Home as u8, KeyFlags::default());
+pub const Key_Keypad8: Key = Key::new(KBU::Keypad8UpArrow as u8, KeyFlags::default());
+pub const Key_Keypad9: Key = Key::new(KBU::Keypad9PageUp as u8, KeyFlags::default());
+pub const Key_Keypad0: Key = Key::new(KBU::Keypad0Insert as u8, KeyFlags::default());
+pub const Key_KeypadDot: Key = Key::new(KBU::KeypadPeriodDelete as u8, KeyFlags::default());
+pub const Key_NonUsBackslashAndPipe: Key =
+    Key::new(KBU::KeyboardNonUSSlash as u8, KeyFlags::default());
+pub const Key_PcApplication: Key = Key::new(KBU::KeyboardApplication as u8, KeyFlags::default());
+pub const Key_Power: Key = Key::new(KBU::KeyboardPower as u8, KeyFlags::default());
+pub const Key_KeypadEquals: Key = Key::new(KBU::KeypadEqual as u8, KeyFlags::default());
+pub const Key_F13: Key = Key::new(KBU::KeyboardF13 as u8, KeyFlags::default());
+pub const Key_F14: Key = Key::new(KBU::KeyboardF14 as u8, KeyFlags::default());
+pub const Key_F15: Key = Key::new(KBU::KeyboardF15 as u8, KeyFlags::default());
+pub const Key_F16: Key = Key::new(KBU::KeyboardF16 as u8, KeyFlags::default());
+pub const Key_F17: Key = Key::new(KBU::KeyboardF17 as u8, KeyFlags::default());
+pub const Key_F18: Key = Key::new(KBU::KeyboardF18 as u8, KeyFlags::default());
+pub const Key_F19: Key = Key::new(KBU::KeyboardF19 as u8, KeyFlags::default());
+pub const Key_F20: Key = Key::new(KBU::KeyboardF20 as u8, KeyFlags::default());
+pub const Key_F21: Key = Key::new(KBU::KeyboardF21 as u8, KeyFlags::default());
+pub const Key_F22: Key = Key::new(KBU::KeyboardF22 as u8, KeyFlags::default());
+pub const Key_F23: Key = Key::new(KBU::KeyboardF23 as u8, KeyFlags::default());
+pub const Key_F24: Key = Key::new(KBU::KeyboardF24 as u8, KeyFlags::default());
+pub const Key_Execute: Key = Key::new(KBU::KeyboardExecute as u8, KeyFlags::default());
+pub const Key_Help: Key = Key::new(KBU::KeyboardHelp as u8, KeyFlags::default());
+pub const Key_Menu: Key = Key::new(KBU::KeyboardMenu as u8, KeyFlags::default());
+pub const Key_Select: Key = Key::new(KBU::KeyboardSelect as u8, KeyFlags::default());
+pub const Key_Stop: Key = Key::new(KBU::KeyboardStop as u8, KeyFlags::default());
+pub const Key_Again: Key = Key::new(KBU::KeyboardAgain as u8, KeyFlags::default());
+pub const Key_Undo: Key = Key::new(KBU::KeyboardUndo as u8, KeyFlags::default());
+pub const Key_Cut: Key = Key::new(KBU::KeyboardCut as u8, KeyFlags::default());
+pub const Key_Copy: Key = Key::new(KBU::KeyboardCopy as u8, KeyFlags::default());
+pub const Key_Paste: Key = Key::new(KBU::KeyboardPaste as u8, KeyFlags::default());
+pub const Key_Find: Key = Key::new(KBU::KeyboardFind as u8, KeyFlags::default());
+pub const Key_Mute: Key = Key::new(KBU::KeyboardMute as u8, KeyFlags::default());
+pub const Key_VolumeUp: Key = Key::new(KBU::KeyboardVolumeUp as u8, KeyFlags::default());
+pub const Key_VolumeDown: Key = Key::new(KBU::KeyboardVolumeDown as u8, KeyFlags::default());
+pub const Key_LockingCapsLock: Key =
+    Key::new(KBU::KeyboardLockingCapsLock as u8, KeyFlags::default());
+pub const Key_LockingNumLock: Key =
+    Key::new(KBU::KeyboardLockingNumLock as u8, KeyFlags::default());
+pub const Key_LockingScrollLock: Key =
+    Key::new(KBU::KeyboardLockingScrollLock as u8, KeyFlags::default());
+pub const Key_KeypadComma: Key = Key::new(KBU::KeypadComma as u8, KeyFlags::default());
+pub const Key_KeypadEqualSign: Key = Key::new(KBU::KeypadEqualSign as u8, KeyFlags::default());
+pub const Key_International1: Key =
+    Key::new(KBU::KeyboardInternational1 as u8, KeyFlags::default());
+pub const Key_International2: Key =
+    Key::new(KBU::KeyboardInternational2 as u8, KeyFlags::default());
+pub const Key_International3: Key =
+    Key::new(KBU::KeyboardInternational3 as u8, KeyFlags::default());
+pub const Key_International4: Key =
+    Key::new(KBU::KeyboardInternational4 as u8, KeyFlags::default());
+pub const Key_International5: Key =
+    Key::new(KBU::KeyboardInternational5 as u8, KeyFlags::default());
+pub const Key_International6: Key =
+    Key::new(KBU::KeyboardInternational6 as u8, KeyFlags::default());
+pub const Key_International7: Key =
+    Key::new(KBU::KeyboardInternational7 as u8, KeyFlags::default());
+pub const Key_International8: Key =
+    Key::new(KBU::KeyboardInternational8 as u8, KeyFlags::default());
+pub const Key_International9: Key =
+    Key::new(KBU::KeyboardInternational9 as u8, KeyFlags::default());
+pub const Key_Lang1: Key = Key::new(KBU::KeyboardLANG1 as u8, KeyFlags::default());
+pub const Key_Lang2: Key = Key::new(KBU::KeyboardLANG2 as u8, KeyFlags::default());
+pub const Key_Lang3: Key = Key::new(KBU::KeyboardLANG3 as u8, KeyFlags::default());
+pub const Key_Lang4: Key = Key::new(KBU::KeyboardLANG4 as u8, KeyFlags::default());
+pub const Key_Lang5: Key = Key::new(KBU::KeyboardLANG5 as u8, KeyFlags::default());
+pub const Key_Lang6: Key = Key::new(KBU::KeyboardLANG6 as u8, KeyFlags::default());
+pub const Key_Lang7: Key = Key::new(KBU::KeyboardLANG7 as u8, KeyFlags::default());
+pub const Key_Lang8: Key = Key::new(KBU::KeyboardLANG8 as u8, KeyFlags::default());
+pub const Key_Lang9: Key = Key::new(KBU::KeyboardLANG9 as u8, KeyFlags::default());
+pub const Key_AlternateErase: Key =
+    Key::new(KBU::KeyboardAlternateErase as u8, KeyFlags::default());
+pub const Key_SysReq: Key = Key::new(KBU::KeyboardSysReqAttention as u8, KeyFlags::default());
+pub const Key_Cancel: Key = Key::new(KBU::KeyboardCancel as u8, KeyFlags::default());
+pub const Key_Clear: Key = Key::new(KBU::KeyboardClear as u8, KeyFlags::default());
+pub const Key_Prior: Key = Key::new(KBU::KeyboardPrior as u8, KeyFlags::default());
+pub const Key_Return: Key = Key::new(KBU::KeyboardReturn as u8, KeyFlags::default());
+pub const Key_Separator: Key = Key::new(KBU::KeyboardSeparator as u8, KeyFlags::default());
+pub const Key_Out: Key = Key::new(KBU::KeyboardOut as u8, KeyFlags::default());
+pub const Key_Oper: Key = Key::new(KBU::KeyboardOper as u8, KeyFlags::default());
+pub const Key_ClearSlashAgain: Key = Key::new(KBU::KeyboardClearAgain as u8, KeyFlags::default());
+pub const Key_CrSelSlashProps: Key = Key::new(KBU::KeyboardCrSelProps as u8, KeyFlags::default());
+pub const Key_Exsel: Key = Key::new(KBU::KeyboardExSel as u8, KeyFlags::default());
+pub const Key_Keypad00: Key = Key::new(KBU::Keypad00 as u8, KeyFlags::default());
+pub const Key_Keypad000: Key = Key::new(KBU::Keypad000 as u8, KeyFlags::default());
+pub const Key_ThousandsSeparator: Key =
+    Key::new(KBU::ThousandsSeparator as u8, KeyFlags::default());
+pub const Key_DecimalSeparator: Key = Key::new(KBU::DecimalSeparator as u8, KeyFlags::default());
+pub const Key_CurrencyUnit: Key = Key::new(KBU::CurrencyUnit as u8, KeyFlags::default());
+pub const Key_CurrencySubunit: Key = Key::new(KBU::CurrencyUnit as u8, KeyFlags::default());
+pub const Key_KeypadLeftParen: Key = Key::new(KBU::KeypadOpenParens as u8, KeyFlags::default());
+pub const Key_KeypadRightParen: Key = Key::new(KBU::KeypadCloseParens as u8, KeyFlags::default());
+pub const Key_LeftCurlyBracket: Key = Key::new(KBU::KeypadOpenBrace as u8, KeyFlags::default());
+pub const Key_RightCurlyBracket: Key = Key::new(KBU::KeypadCloseBrace as u8, KeyFlags::default());
+pub const Key_KeypadTab: Key = Key::new(KBU::KeypadTab as u8, KeyFlags::default());
+pub const Key_KeypadBackspace: Key = Key::new(KBU::KeypadBackspace as u8, KeyFlags::default());
+pub const Key_KeypadA: Key = Key::new(KBU::KeypadA as u8, KeyFlags::default());
+pub const Key_KeypadB: Key = Key::new(KBU::KeypadB as u8, KeyFlags::default());
+pub const Key_KeypadC: Key = Key::new(KBU::KeypadC as u8, KeyFlags::default());
+pub const Key_KeypadD: Key = Key::new(KBU::KeypadD as u8, KeyFlags::default());
+pub const Key_KeypadE: Key = Key::new(KBU::KeypadE as u8, KeyFlags::default());
+pub const Key_KeypadF: Key = Key::new(KBU::KeypadF as u8, KeyFlags::default());
+pub const Key_KeypadXor: Key = Key::new(KBU::KeypadBitwiseXor as u8, KeyFlags::default());
+pub const Key_KeypadCarat: Key = Key::new(KBU::KeypadLogicalXor as u8, KeyFlags::default());
+pub const Key_KeypadPercent: Key = Key::new(KBU::KeypadModulo as u8, KeyFlags::default());
+pub const Key_KeypadLessThan: Key = Key::new(KBU::KeypadLeftShift as u8, KeyFlags::default());
+pub const Key_KeypadGreaterThan: Key = Key::new(KBU::KeypadRightShift as u8, KeyFlags::default());
+pub const Key_KeypadAmpersand: Key = Key::new(KBU::KeypadBitwiseAnd as u8, KeyFlags::default());
+pub const Key_KeypadDoubleAmpersand: Key =
+    Key::new(KBU::KeypadLogicalAnd as u8, KeyFlags::default());
+pub const Key_KeypadPipe: Key = Key::new(KBU::KeypadBitwiseOr as u8, KeyFlags::default());
+pub const Key_KeypadDoublePipe: Key = Key::new(KBU::KeypadLogicalOr as u8, KeyFlags::default());
+pub const Key_KeypadColon: Key = Key::new(KBU::KeypadColon as u8, KeyFlags::default());
+pub const Key_KeypadPoundSign: Key = Key::new(KBU::KeypadHash as u8, KeyFlags::default());
+pub const Key_KeypadSpace: Key = Key::new(KBU::KeypadSpace as u8, KeyFlags::default());
+pub const Key_KeypadAtSign: Key = Key::new(KBU::KeypadAt as u8, KeyFlags::default());
+pub const Key_KeypadExclamationPoint: Key =
+    Key::new(KBU::KeypadExclamation as u8, KeyFlags::default());
+pub const Key_KeypadMemoryStore: Key = Key::new(KBU::KeypadMemoryStore as u8, KeyFlags::default());
+pub const Key_KeypadMemoryRecall: Key =
+    Key::new(KBU::KeypadMemoryRecall as u8, KeyFlags::default());
+pub const Key_KeypadMemoryClear: Key = Key::new(KBU::KeypadMemoryClear as u8, KeyFlags::default());
+pub const Key_KeypadMemoryAdd: Key = Key::new(KBU::KeypadMemoryAdd as u8, KeyFlags::default());
+pub const Key_KeypadMemorySubtract: Key =
+    Key::new(KBU::KeypadMemorySubtract as u8, KeyFlags::default());
+pub const Key_KeypadMemoryMultiply: Key =
+    Key::new(KBU::KeypadMemoryMultiply as u8, KeyFlags::default());
+pub const Key_KeypadMemoryDivide: Key =
+    Key::new(KBU::KeypadMemoryDivide as u8, KeyFlags::default());
+pub const Key_KeypadPlusSlashMinus: Key =
+    Key::new(KBU::KeypadPositiveNegative as u8, KeyFlags::default());
+pub const Key_KeypadClear: Key = Key::new(KBU::KeypadClear as u8, KeyFlags::default());
+pub const Key_KeypadClearEntry: Key = Key::new(KBU::KeypadClearEntry as u8, KeyFlags::default());
+pub const Key_KeypadBinary: Key = Key::new(KBU::KeypadBinary as u8, KeyFlags::default());
+pub const Key_KeypadOctal: Key = Key::new(KBU::KeypadOctal as u8, KeyFlags::default());
+pub const Key_KeypadDecimal: Key = Key::new(KBU::KeypadDecimal as u8, KeyFlags::default());
+pub const Key_KeypadHexadecimal: Key = Key::new(KBU::KeypadHexadecimal as u8, KeyFlags::default());
+pub const Key_LeftControl: Key = Key::new(KBU::KeyboardLeftControl as u8, KeyFlags::default());
+pub const Key_LeftShift: Key = Key::new(KBU::KeyboardLeftShift as u8, KeyFlags::default());
+pub const Key_LeftAlt: Key = Key::new(KBU::KeyboardLeftAlt as u8, KeyFlags::default());
+pub const Key_LeftGui: Key = Key::new(KBU::KeyboardLeftGUI as u8, KeyFlags::default());
+pub const Key_RightControl: Key = Key::new(KBU::KeyboardRightControl as u8, KeyFlags::default());
+pub const Key_RightShift: Key = Key::new(KBU::KeyboardRightShift as u8, KeyFlags::default());
+pub const Key_RightAlt: Key = Key::new(KBU::KeyboardRightAlt as u8, KeyFlags::default());
+pub const Key_RightGui: Key = Key::new(KBU::KeyboardRightGUI as u8, KeyFlags::default());

--- a/src/key_defs/keymaps.rs
+++ b/src/key_defs/keymaps.rs
@@ -1,0 +1,47 @@
+use super::*;
+
+pub const LAYER_OP_OFFSET: u8 = 42;
+pub const LAYER_SHIFT_OFFSET: u8 = LAYER_OP_OFFSET;
+pub const LAYER_MOVE_OFFSET: u8 = LAYER_SHIFT_OFFSET + LAYER_OP_OFFSET;
+
+pub const KEYMAP_PREVIOUS: u8 = 33;
+pub const KEYMAP_NEXT: u8 = 34;
+
+pub const fn shift_to_layer(n: u8) -> Key {
+    Key::new(
+        n + LAYER_SHIFT_OFFSET,
+        KeyFlags(KEY_FLAGS | SYNTHETIC | SWITCH_TO_KEYMAP),
+    )
+}
+
+pub const fn lock_layer(n: u8) -> Key {
+    Key::new(n, KeyFlags(KEY_FLAGS | SYNTHETIC | SWITCH_TO_KEYMAP))
+}
+
+pub const fn move_to_layer(n: u8) -> Key {
+    Key::new(
+        n + LAYER_MOVE_OFFSET,
+        KeyFlags(KEY_FLAGS | SYNTHETIC | SWITCH_TO_KEYMAP),
+    )
+}
+
+#[macro_export]
+macro_rules! MO {
+    ($key:tt) => {
+        $crate::key_defs::keymaps::shift_to_layer($key)
+    };
+}
+
+#[macro_export]
+macro_rules! TG {
+    ($key:tt) => {
+        $crate::key_defs::keymaps::lock_layer($key)
+    };
+}
+
+#[macro_export]
+macro_rules! ML {
+    ($key:tt) => {
+        $crate::key_defs::keymaps::move_to_layer($key)
+    };
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,23 @@
+//! Common types and functionality for Kaleidoscope libraries.
+//!
+//! Separated out to make unit and integration testing easier.
+//!
+//! Structures and functionality do not depend on hardware-specific features, allowing for
+//! platform-independent testing.
+
 #![no_std]
 
+#[macro_use(bitfield)]
+extern crate bitfield;
+
+// Re-exports
+pub use usbd_hid;
+
+/// HID table constants
+pub mod hid_tables;
+
+/// Key definitions
+pub mod key_defs;
+
+/// Matrix address
 pub mod matrix_addr;

--- a/src/matrix_addr.rs
+++ b/src/matrix_addr.rs
@@ -39,7 +39,9 @@ impl<const ROWS: u8, const COLS: u8> MatrixAddr<ROWS, COLS> {
     pub const fn default() -> Self {
         Self::invariant();
 
-        Self { offset: ROWS * COLS }
+        Self {
+            offset: ROWS * COLS,
+        }
     }
 
     /// Creates a [MatrixAddr] from another [MatrixAddr].
@@ -116,13 +118,17 @@ impl<const ROWS: u8, const COLS: u8> MatrixAddr<ROWS, COLS> {
     }
 }
 
-impl<const R1: u8, const C1: u8, const R2: u8, const C2: u8> PartialEq<MatrixAddr<R2, C2>> for MatrixAddr<R1, C1> {
+impl<const R1: u8, const C1: u8, const R2: u8, const C2: u8> PartialEq<MatrixAddr<R2, C2>>
+    for MatrixAddr<R1, C1>
+{
     fn eq(&self, rhs: &MatrixAddr<R2, C2>) -> bool {
         self.offset == rhs.offset
     }
 }
 
-impl<const R1: u8, const C1: u8, const R2: u8, const C2: u8> PartialOrd<MatrixAddr<R2, C2>> for MatrixAddr<R1, C1> {
+impl<const R1: u8, const C1: u8, const R2: u8, const C2: u8> PartialOrd<MatrixAddr<R2, C2>>
+    for MatrixAddr<R1, C1>
+{
     fn partial_cmp(&self, rhs: &MatrixAddr<R2, C2>) -> Option<core::cmp::Ordering> {
         if self.row() == rhs.row() && self.col() == rhs.col() {
             Some(core::cmp::Ordering::Equal)

--- a/tests/matrix_addr.rs
+++ b/tests/matrix_addr.rs
@@ -4,10 +4,16 @@ type MA1 = MatrixAddr<7, 14>;
 type MA2 = MatrixAddr<7, 8>;
 type MA3 = MatrixAddr<7, 5>;
 type MA4 = MatrixAddr<4, 12>;
-    
+
 fn test_indexed_access<const R: u8, const C: u8>(mut ma: MatrixAddr<R, C>) {
     let row = if R > 1 { 1 } else { 0 };
-    let col = if C > 3 { 3 } else if C > 1 { C - 1 } else { 0 };
+    let col = if C > 3 {
+        3
+    } else if C > 1 {
+        C - 1
+    } else {
+        0
+    };
 
     ma.set_row(1);
     ma.set_col(col);
@@ -36,7 +42,13 @@ fn test_relation<const R1: u8, const C1: u8, const R2: u8, const C2: u8>(
     _ma2: MatrixAddr<R2, C2>,
 ) {
     let row1 = if R1 > 4 { R1 - 4 } else { R1 - 1 };
-    let row2 = if R2 > 5 { R2 - 5 } else if R2 > 2 { R2 - 2 } else { 0 };
+    let row2 = if R2 > 5 {
+        R2 - 5
+    } else if R2 > 2 {
+        R2 - 2
+    } else {
+        0
+    };
 
     let col1 = C1 - 1;
     let col2 = C2 - 1;


### PR DESCRIPTION
Adds new module for key definitions for boot, NKRO, media, and system keyboard classes.