### PR TITLE
ci: add Github CI runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,82 @@
+name: CI
+on: [push, pull_request]
+
+jobs:
+  test-nightly:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+        rust: [nightly]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{ matrix.rust }}
+          override: true
+      - name: Run tests (no_std)
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --tests --no-default-features
+      - name: Run tests (avr)
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --no-default-features --features avr
+      - name: Run tests (atmega32u4)
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --no-default-features --features atmega32u4
+      - name: Run tests (atreus)
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --no-default-features --features atreus
+      - name: Run tests (all)
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --all-features
+  test-stable:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+        rust: [stable]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{ matrix.rust }}
+          override: true
+      - name: Run tests (no_std)
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --no-default-features
+      - name: Run tests (avr)
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --no-default-features --features avr
+      - name: Run tests (atmega32u4)
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --no-default-features --features atmega32u4
+      - name: Run tests (atreus)
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --no-default-features --features atreus
+      - name: Run tests (all)
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --all-features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,5 +14,5 @@ version = "0.6"
 
 [features]
 avr = []
-atmega32u4 = []
-atreus = ["atmega32u4", "avr"]
+atmega32u4 = ["avr"]
+atreus = ["atmega32u4"]

--- a/src/device.rs
+++ b/src/device.rs
@@ -1,7 +1,7 @@
-#[cfg(feature = "avr")]
+#[cfg(any(feature = "avr", feature = "atmega32u4"))]
 mod avr;
 
-#[cfg(feature = "avr")]
+#[cfg(any(feature = "avr", feature = "atmega32u4"))]
 pub use avr::*;
 
 pub mod key_indexes;

--- a/src/driver/bootloader.rs
+++ b/src/driver/bootloader.rs
@@ -1,4 +1,4 @@
-#[cfg(feature = "avr")]
+#[cfg(any(feature = "avr", feature = "atmega32u4"))]
 pub mod avr;
 
 pub trait Base {

--- a/src/driver/keyscanner/atmega.rs
+++ b/src/driver/keyscanner/atmega.rs
@@ -1,4 +1,4 @@
-#[cfg(feature = "atreus")]
+#[cfg(any(feature = "atreus", feature = "atmega32u4"))]
 use crate::plugins::atreus::DeviceProps;
 
 use super::{DummyScanner, KeyScannerProps};

--- a/src/key_addr.rs
+++ b/src/key_addr.rs
@@ -1,9 +1,9 @@
 #[cfg(feature = "atreus")]
 mod atreus;
-#[cfg(not(any(feature = "atreus", feature = "avr", feature = "atmega32u4")))]
+#[cfg(any(not(feature = "atreus"), not(feature = "atmega32u4"), not(feature = "avr")))]
 mod dummy;
 
 #[cfg(feature = "atreus")]
 pub use atreus::*;
-#[cfg(not(any(feature = "atreus", feature = "avr", feature = "atmega32u4")))]
+#[cfg(any(not(feature = "atreus"), not(feature = "atmega32u4"), not(feature = "avr")))]
 pub use dummy::*;

--- a/src/plugins.rs
+++ b/src/plugins.rs
@@ -1,5 +1,5 @@
 /// Keyboardio Atreus hardware support
-#[cfg(feature = "atreus")]
+#[cfg(any(feature = "atreus", feature = "atmega32u4"))]
 pub mod atreus;
 pub mod macros;
 pub mod ranges;


### PR DESCRIPTION
Adds basic runners for all tests, with stable and nightly toolchains.